### PR TITLE
added tooltip to sliders with allowOutOfBounds=true

### DIFF
--- a/src/main/kotlin/dev/lyzev/api/setting/settings/SettingClientSlider.kt
+++ b/src/main/kotlin/dev/lyzev/api/setting/settings/SettingClientSlider.kt
@@ -87,6 +87,7 @@ class SettingClientSlider<T : Number>(
                     MathHelper.clamp(f[0], minValue.toFloat(), maxValue.toFloat()) as T
             }
         }
+        if (isItemHovered()) setTooltip((if (allowOutOfBounds) "Out of bounds values are allowed, use with caution." else "Range: $minValue $unit - $maxValue $unit") + "\nPress CTRL + click to set a specific value.")
     }
 
     override fun setValue(ref: Any, prop: KProperty<*>, value: T) {


### PR DESCRIPTION
there is a tooltip for every slider now

1. allowOutOfBounds=true
![image](https://github.com/Lyzev/Schizoid/assets/69327579/aa11997a-4013-47ba-adc9-4bef8b321f0e)

2. allowOutOfBounds=false
![image](https://github.com/Lyzev/Schizoid/assets/69327579/c30ae6b3-2cf0-42af-881d-3a7205da0d36)


close #65 